### PR TITLE
Ensure function generate-project-speculations can write to database after enabling RLS and db policies

### DIFF
--- a/src-supabase/supabase/functions/generate-project-speculations/database/project-speculation.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/database/project-speculation.ts
@@ -9,6 +9,7 @@ const create = async (
 ) => {
   const sentences = input.sentences ?? [];
   const values = sentences.map((sentence) => ({
+    user_id: input.project.user_id,
     project_id: input.project.project_id,
     sentence,
   }));

--- a/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
@@ -11,7 +11,7 @@ const getById = async (
 ): Promise<IProject | null> => {
   const { data, error } = await SupabaseClient()
     .from("project")
-    .select("project_id, name, description").eq("project_id", projectId).limit(
+    .select("project_id, user_id, name, description").eq("project_id", projectId).limit(
       1,
     );
 

--- a/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
@@ -2,6 +2,7 @@ import { SupabaseClient } from "./supabase.client.ts";
 
 export interface IProject {
   project_id: string;
+  user_id: string;
   name: string;
   description: string;
 }

--- a/src-supabase/supabase/functions/generate-project-speculations/database/supabase.client.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/database/supabase.client.ts
@@ -3,6 +3,6 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 export const SupabaseClient = () => {
   return createClient(
     Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
   );
 };

--- a/src-supabase/supabase/migrations/20240418141002_trigger_generate_sentences.sql
+++ b/src-supabase/supabase/migrations/20240418141002_trigger_generate_sentences.sql
@@ -57,8 +57,9 @@ BEGIN
     
     -- Make request to edge function
     PERFORM net.http_post(
-        api_url,
-        format('{ "projectId": "%s"}', NEW.project_id)::JSONB
+        url := api_url,
+        body := format('{ "projectId": "%s"}', NEW.project_id)::JSONB,
+        timeout_milliseconds := 60000
     ) AS request_id;
 
     RETURN NEW;


### PR DESCRIPTION
Adjust the function `generate-project-speculations` to:
- use the **Service Role Key** for database connections, enabling it to write data on behalf of the user;
- fills in the `user_id` when inserting data into `project_speculations`;

These changes are necessary after enabling RLS and adding database policies, without which the function would not be able to write data into `project_speculation`.