### PR TITLE
Prevent generating new speculations if project already has some

### DIFF
--- a/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
@@ -5,6 +5,7 @@ export interface IProject {
   user_id: string;
   name: string;
   description: string;
+  project_speculation: Record<string, number>[];
 }
 
 const getById = async (

--- a/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/database/project.ts
@@ -12,9 +12,9 @@ const getById = async (
 ): Promise<IProject | null> => {
   const { data, error } = await SupabaseClient()
     .from("project")
-    .select("project_id, user_id, name, description").eq("project_id", projectId).limit(
-      1,
-    );
+    .select("project_id, user_id, name, description, project_speculation(project_speculation_id)")
+    .eq("project_id", projectId)
+    .limit(1);
 
   if (error) {
     throw new Error(error.message);

--- a/src-supabase/supabase/functions/generate-project-speculations/index.ts
+++ b/src-supabase/supabase/functions/generate-project-speculations/index.ts
@@ -42,6 +42,14 @@ const handleRequest = async (req: Request) => {
       });
     }
 
+    // If the project already has speculations, return 204 so no new ones are generated
+    if (project.project_speculation?.length) {
+      return new Response(null, {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 204, // it's not an error, but there's no content to generate/return
+      });
+    }
+
     const { sentences } = await generateSentences({ project });
     await ProjectSpeculation.create({ project, sentences });
 


### PR DESCRIPTION
Prevent generating new speculations if project already has some. This will ensure no new ones are generated when toggling on/off the checkbox and saving again the project